### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Blank lines are skipped while parsing
 - Valid `ouput` ports are `F8`, `F9`, `FA` and `FB`.
 - Specifying any other `input` or `output` port will result in a `logic error`.
 - Same as `MEM`, to read / write data to any `I/O` port, you will need to use `regs`.
-- The compiled code is compatible with `x64` architecture **only**.
+- The compiled binaries are compatible with `x64` architecture **only**.
 
 [1]: https://ahduni.edu.in/academics/schools-centres/school-of-engineering-and-applied-science/people-1/mazad-zaveri/
 [2]: https://ahduni.edu.in/academics/schools-centres/school-of-engineering-and-applied-science/


### PR DESCRIPTION
Changed code to binaries to avoid confusion.
Basically, people would have gotten confused whether the compiled code referred to the pre-compiled binaries in bin folder, or the assembly code they would compile for this processor model, which now that I think about it, seems obvious. Still, made the change.